### PR TITLE
Displaying web/frontend versions in footer

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,13 +9,14 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 
 import './app.scss';
+import packageInfo from '../package.json';
 import {QueryForm} from './queryForm.js';
 import {GrnaQueryForm} from './grnaQueryForm.js';
 import {LibraryQueryForm} from './libraryQueryForm.js';
 import {DownloadsPage} from './downloadsPage.js';
 import {AboutPage} from './aboutPage';
 import {ContactPage} from './contactPage';
-import {submitQuery, submitGrnaQuery, submitLibraryQuery} from './jobs/rest';
+import {getInfoSupported, submitQuery, submitGrnaQuery, submitLibraryQuery} from './jobs/rest';
 import {JobPage} from './jobs/jobPage';
 
 import {
@@ -148,8 +149,13 @@ const QueryState = {
 };
 
 function App() {
+    const [webversion, setWebVersion] = useState("");
     const [queryState, updateQueryState] = useState(QueryState.NOT_SUBMITTED);
     const navigate = useNavigate();
+
+    useEffect(() => {
+        getInfoSupported((response) => setWebVersion(response.data["version"]))
+    }, []);
 
     function handleSuccessfulQuery(response) {
         updateQueryState(QueryState.SUCCESS);
@@ -196,6 +202,11 @@ function App() {
         </Routes>
         {successToast}
         {failureToast}
+        <footer className="footer mt-auto py-3">
+          <div className="container justify-content-center text-center">
+            <span className="text-muted">Guidescan Web v{webversion}, Frontend v{packageInfo.version}</span>
+          </div>
+        </footer>
       </div>
     );
 }


### PR DESCRIPTION
Once the PR for returning version for `guidescan-web` is merged in, this PR will help in displaying both the web+frontend versions in the site footer. I've tested this locally and it works fine.

Getting the version from `package.json` was something I got from StackOverflow. Though there's widespread agreement that reading in `package.json` means it gets delivered to the client (and is thus a security risk), for open-source projects like ours where the `package.json` is public anyway, it shouldn't be an issue. I think having a ready way to verify the version trumps that concern. If you think it's a problem, perhaps we can open up an issue and tackle it at some point?