### PR TITLE
changes to not support dna seq for genomic coords anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guidescan-frontend",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.2",

--- a/src/queryForm.js
+++ b/src/queryForm.js
@@ -542,9 +542,7 @@ class QueryForm extends React.Component {
           <hr style={margin_style("1.75em 0 1.75em 0")}/>
           <TextInput
             display={"Input genomic coordinates as chromosome:start-end, organism \
-                      appropriate gene symbol, or Entrez GeneIDs. Submit one genomic coordinate per line.\
-                      Alternatively, one can submit a genome sequence that will be searched within the genome\
-                      of interest."}
+                      appropriate gene symbol, or Entrez GeneIDs. Submit one genomic coordinate per line."}
             onTextChange={this.handleQueryTextChange}
             text={this.state.query_text}/>
           <h2 style={R.mergeRight(italics_style, center_style)}>


### PR DESCRIPTION
I'll send a corresponding PR to strip the sequence search logic from the web backend (with matching version number).